### PR TITLE
feature: movie 관련 리스트 조회 API 구현

### DIFF
--- a/src/main/kotlin/com/weeds/movie/controller/MovieController.kt
+++ b/src/main/kotlin/com/weeds/movie/controller/MovieController.kt
@@ -1,11 +1,14 @@
 package com.weeds.movie.controller
 
+import com.weeds.movie.domain.movie.MediaType
+import com.weeds.movie.domain.movie.PlayType
 import com.weeds.movie.service.MovieService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -17,5 +20,23 @@ class MovieController(
     fun getMovie(@PathVariable movieId: Long) =
         ResponseEntity.status(HttpStatus.OK).body(
             movieService.getMovie(movieId)
+        )
+
+    @GetMapping("/playType")
+    fun getMovieListByPlayType(@RequestParam playType: PlayType) =
+        ResponseEntity.status(HttpStatus.OK).body(
+            movieService.getMovieListByPlayType(playType)
+        )
+
+    @GetMapping("/mediaType")
+    fun getMovieListByMediaType(@RequestParam mediaType: MediaType) =
+        ResponseEntity.status(HttpStatus.OK).body(
+            movieService.getMovieListByMediaType(mediaType)
+        )
+
+    @GetMapping("/trailer")
+    fun getLatestTrailerListByPlayType(@RequestParam playType: PlayType) =
+        ResponseEntity.status(HttpStatus.OK).body(
+            movieService.getLatestTrailerListByPlayType(playType)
         )
 }

--- a/src/main/kotlin/com/weeds/movie/dto/movie/MovieListDTO.kt
+++ b/src/main/kotlin/com/weeds/movie/dto/movie/MovieListDTO.kt
@@ -1,0 +1,39 @@
+package com.weeds.movie.dto.movie
+
+import com.weeds.movie.domain.movie.FileType
+import com.weeds.movie.domain.movie.Movie
+import com.weeds.movie.domain.movie.MovieAttachments
+import java.time.Instant
+
+data class MovieListDTO(
+    val movieId: Long,
+    val title: String,
+    val openedAt: Instant
+) {
+    companion object {
+        fun of(movie: Movie) = MovieListDTO(
+            movieId = movie.id,
+            title = movie.title,
+            openedAt = movie.openedAt
+        )
+    }
+}
+
+data class MovieTrailerListDTO(
+    val movieId: Long,
+    val title: String,
+    val trailerUrl: String?
+) {
+    companion object {
+        fun of(movie: Movie) = MovieTrailerListDTO(
+            movieId = movie.id,
+            title = movie.title,
+            trailerUrl = checkVideo(movie.attachments)?.lastOrNull()?.fileUrl
+        )
+
+        private fun checkVideo(attachments: List<MovieAttachments>?) =
+            attachments?.filter {
+                it.type == FileType.VIDEO
+            }
+    }
+}

--- a/src/main/kotlin/com/weeds/movie/repository/movie/MovieRepository.kt
+++ b/src/main/kotlin/com/weeds/movie/repository/movie/MovieRepository.kt
@@ -1,7 +1,12 @@
 package com.weeds.movie.repository.movie
 
+import com.weeds.movie.domain.movie.MediaType
 import com.weeds.movie.domain.movie.Movie
+import com.weeds.movie.domain.movie.PlayType
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface MovieRepository: JpaRepository<Movie, Long> {
+    fun findAllByPlayType(playType: PlayType): List<Movie>
+
+    fun findAllByMediaType(mediaType: MediaType): List<Movie>
 }

--- a/src/main/kotlin/com/weeds/movie/service/MovieService.kt
+++ b/src/main/kotlin/com/weeds/movie/service/MovieService.kt
@@ -1,8 +1,16 @@
 package com.weeds.movie.service
 
+import com.weeds.movie.domain.movie.MediaType
+import com.weeds.movie.domain.movie.PlayType
+import com.weeds.movie.dto.common.ListPageResponse
 import com.weeds.movie.dto.common.ResultResponse
 import com.weeds.movie.dto.movie.MovieDTO
+import com.weeds.movie.dto.movie.MovieListDTO
+import com.weeds.movie.dto.movie.MovieTrailerListDTO
 
 interface MovieService {
     fun getMovie(movieId: Long): ResultResponse<MovieDTO>
+    fun getMovieListByPlayType(playType: PlayType): ListPageResponse<MovieListDTO>
+    fun getMovieListByMediaType(mediaType: MediaType): ListPageResponse<MovieListDTO>
+    fun getLatestTrailerListByPlayType(playType: PlayType): ListPageResponse<MovieTrailerListDTO>
 }

--- a/src/main/kotlin/com/weeds/movie/service/MovieServiceImpl.kt
+++ b/src/main/kotlin/com/weeds/movie/service/MovieServiceImpl.kt
@@ -55,6 +55,7 @@ class MovieServiceImpl(
     @Transactional
     override fun getLatestTrailerListByPlayType(playType: PlayType): ListPageResponse<MovieTrailerListDTO> {
         val response = movieRepository.findAllByPlayType(playType)
+            .sortedByDescending { it.createdAt }
 
         return ListPageResponse(
             result = response.map(MovieTrailerListDTO::of),

--- a/src/main/kotlin/com/weeds/movie/service/MovieServiceImpl.kt
+++ b/src/main/kotlin/com/weeds/movie/service/MovieServiceImpl.kt
@@ -1,9 +1,14 @@
 package com.weeds.movie.service
 
+import com.weeds.movie.domain.movie.MediaType
 import com.weeds.movie.dto.common.ResultResponse
 import com.weeds.movie.domain.movie.Movie
+import com.weeds.movie.domain.movie.PlayType
 import com.weeds.movie.domain.trend.Trend
+import com.weeds.movie.dto.common.ListPageResponse
 import com.weeds.movie.dto.movie.MovieDTO
+import com.weeds.movie.dto.movie.MovieListDTO
+import com.weeds.movie.dto.movie.MovieTrailerListDTO
 import com.weeds.movie.repository.movie.MovieRepository
 import com.weeds.movie.repository.trend.TrendRepository
 import com.weeds.movie.util.findByIdOrThrow
@@ -24,6 +29,37 @@ class MovieServiceImpl(
         ).also {
             createTrend(movie)
         }
+    }
+
+    @Transactional
+    override fun getMovieListByPlayType(playType: PlayType): ListPageResponse<MovieListDTO> {
+        val response = movieRepository.findAllByPlayType(playType)
+            .sortedBy { it.hitCount.dec() }
+
+        return ListPageResponse(
+            result = response.map(MovieListDTO::of),
+            totalCount = response.size.toLong()
+        )
+    }
+
+    @Transactional
+    override fun getMovieListByMediaType(mediaType: MediaType): ListPageResponse<MovieListDTO> {
+        val response = movieRepository.findAllByMediaType(mediaType)
+
+        return ListPageResponse(
+            result = response.map(MovieListDTO::of),
+            totalCount = response.size.toLong()
+        )
+    }
+
+    @Transactional
+    override fun getLatestTrailerListByPlayType(playType: PlayType): ListPageResponse<MovieTrailerListDTO> {
+        val response = movieRepository.findAllByPlayType(playType)
+
+        return ListPageResponse(
+            result = response.map(MovieTrailerListDTO::of),
+            totalCount = response.size.toLong()
+        )
     }
 
     private fun createTrend(movie: Movie) {


### PR DESCRIPTION
## 개요
1. 유형별 인기 영화 목록 API (What's Popular List) -> GET /v1/movies/playType
2. 유형별 최신 예고편 목록 API -> GET /v1/movies/trailer
3. Free To Watch 영화 목록 API -> GET /v1/movies/mediaType

## 작업 사항
- 1. 과 2. 의 정렬방식은 각각 인기순, 최신 등록일 순 으로 설정했다.
- 3. 의 경우 정렬방식의 정의를 따로 두지 않았다.